### PR TITLE
Switch to using github built-in token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,8 @@ jobs:
         uses: docker/login-action@v1.8.0
         with:
           registry: ghcr.io
-          username: ${{secrets.CONTAINER_REGISTRY_USER}}
-          password: ${{secrets.CONTAINER_REGISTRY_TOKEN}}
+          username: ${{secrets.CONTAINER_REGISTRY_USERNAME}}
+          password: ${{github.token}}
       - name: Push image
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v2.3.0


### PR DESCRIPTION
The build-in GitHub token now supports the GitHub Container registry. No need for us to use our own PAT. Less attack surface.